### PR TITLE
Create 测试参考文档.md

### DIFF
--- a/测试参考文档.md
+++ b/测试参考文档.md
@@ -1,0 +1,20 @@
+# 测试文档
+
+## 安装系统
+
+  * 把硬盘分区为NTFS和EXT4用于安装windows系统和opentho系统（建议用ubunt的gparted命令）
+  * 先安装window系统到第一分区，然后安装opentho（opentho可以为windows系统添加启动引导项，但是只扫描第一分区，所以把window系统安装到第一分区）
+  
+## 测试工具和文件的准备
+
+  * 将wimlib-imgex工具拷贝到system/bin文件夹之下
+  * 制作wim文件，即将刚刚装的window系统压缩为一个wim文件，命令为：wimlib-imagex  capture   /dev/block/sda1   storage/emulated/legacy/tsing_recovery/win×.wim 
+  * 查看wim文件的SHA-1码，并替换 /storage/emulated/legacy/tsing_recovery/recovery.config 中win×_sha1_stardard的值
+  
+## 测试流程
+
+  * 做好之前的准备之后，点击进入App界面，点击刚才对应的windows系统进行恢复
+  * 云端下载需要将刚才的wim文件放入服务器中才可以准确的下载对应的wim文件
+  
+## 注：
+  因为是恢复特定的windows系统，所以前期准备的工作比较多，即：wim文件、SHA-1码、云端地址都是一一对应的


### PR DESCRIPTION
# 测试文档
## 安装系统
- 把硬盘分区为NTFS和EXT4用于安装windows系统和opentho系统（建议用ubunt的gparted命令）
- 先安装window系统到第一分区，然后安装opentho（opentho可以为windows系统添加启动引导项，但是只扫描第一分区，所以把window系统安装到第一分区）
## 测试工具和文件的准备
- 将wimlib-imgex工具拷贝到system/bin文件夹之下
- 制作wim文件，即将刚刚装的window系统压缩为一个wim文件，命令为：wimlib-imagex  capture   /dev/block/sda1   storage/emulated/legacy/tsing_recovery/win×.wim 
- 查看wim文件的SHA-1码，并替换 /storage/emulated/legacy/tsing_recovery/recovery.config 中win×_sha1_stardard的值
## 测试流程
- 做好之前的准备之后，点击进入App界面，点击刚才对应的windows系统进行恢复
- 云端下载需要将刚才的wim文件放入服务器中才可以准确的下载对应的wim文件
## 注：

  因为是恢复特定的windows系统，所以前期准备的工作比较多，即：wim文件、SHA-1码、云端地址都是一一对应的
